### PR TITLE
Use callbacks for bindings to enable async behavior

### DIFF
--- a/gui/choc_WebView.h
+++ b/gui/choc_WebView.h
@@ -135,7 +135,8 @@ public:
     void navigate (const std::string& url);
 
     /// A callback function which can be passed to bind().
-    using CallbackFn = std::function<choc::value::Value(const choc::value::ValueView& args)>;
+    using ReplyFn = std::function<void(choc::value::Value, std::string)>;
+    using CallbackFn = std::function<void(const choc::value::ValueView& args, ReplyFn&& reply)>;
     /// Binds a C++ function to a named javascript function that can be called
     /// by code running in the browser.
     void bind (const std::string& functionName, CallbackFn&& function);
@@ -1495,17 +1496,23 @@ inline void WebView::invokeBinding (const std::string& msg)
 
         try
         {
-            auto result = b->second (json["params"]);
+            b->second (json["params"], [=](choc::value::Value result, std::string const& errorMessage) {
+                if (!errorMessage.empty())
+                {
+                    auto call = callbackItem + ".reject(" + choc::json::toString(choc::value::createString(errorMessage)) + "); delete " + callbackItem + ";";
+                    evaluateJavascript (call);
+                    return;
+                }
 
-            auto call = callbackItem + ".resolve(" + choc::json::toString (result) + "); delete " + callbackItem + ";";
-            evaluateJavascript (call);
-            return;
+                auto call = callbackItem + ".resolve(" + choc::json::toString (result) + "); delete " + callbackItem + ";";
+                evaluateJavascript (call);
+            });
         }
-        catch (const std::exception&)
-        {}
-
-        auto call = callbackItem + ".reject(); delete " + callbackItem + ";";
-        evaluateJavascript (call);
+        catch (const std::exception& e)
+        {
+            auto call = callbackItem + ".reject(" + choc::json::toString(choc::value::createString(e.what())) + "); delete " + callbackItem + ";";
+            evaluateJavascript (call);
+        }
     }
     catch (const std::exception&)
     {}


### PR DESCRIPTION
Turns this:

```cpp
m_webView->bind("example", [this](const choc::value::ValueView&) -> choc::value::Value {
    if (!isArrayWithNonZeroLength(args))
    {
        return {};
    }

    return doExample(args[0]);
});
```
into this
```cpp
m_webView->bind("example", [this](const choc::value::ValueView& args, choc::ui::WebView::ReplyFn&& reply) {
    if (!isArrayWithNonZeroLength(args))
    {
        return reply({}, "Invalid arguments");
    }

    return reply(doExample(args[0]), {});
});
```
This leans into the already async behavior of choc's binding stuff, using a lambda to enable an async implementation that calls back when it has its value ready (i.e. after a bg thread has finished doing some work). This keeps the sync behavior already have, for cases where we need it, by just synchronously calling the replyFn when we have our value.

