### PR TITLE
update to choc develop with config to enable/disable copy commands

### DIFF
--- a/audio/choc_MIDI.h
+++ b/audio/choc_MIDI.h
@@ -360,8 +360,8 @@ template <typename StorageType>
 template <typename OtherStorage>
 bool Message<StorageType>::operator== (const Message<OtherStorage>& other) const
 {
-    auto len1 = midiData.size();
-    auto len2 = other.data.size();
+    auto len1 = size();
+    auto len2 = other.size();
     return len1 == len2 && memcmp (data(), other.data(), len1) == 0;
 }
 

--- a/gui/choc_WebView.h
+++ b/gui/choc_WebView.h
@@ -122,8 +122,8 @@ public:
         /// need to.
         bool enableDefaultClipboardKeyShortcutsInSafari = true;
 
-        /// On Windows, this will also enable browser implementations of accelerator
-        /// keys (e.g. Ctrl+F for find-in-page)
+        /// On Windows, this will enable browser implementations of accelerator keys
+        /// (e.g. Ctrl+F for find-in-page)
         bool enableWindowsAcceleratorKeys = true;
     };
 

--- a/platform/choc_DisableAllWarnings.h
+++ b/platform/choc_DisableAllWarnings.h
@@ -70,7 +70,8 @@
  #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
  #pragma GCC diagnostic ignored "-Wdeprecated"
  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+ #pragma GCC diagnostic ignored "-Wuse-after-free"
+ #pragma GCC diagnostic ignored "-Warray-bounds"
  #ifndef __MINGW32__
   #pragma GCC diagnostic ignored "-Wredundant-move"
  #endif

--- a/text/choc_JSON.h
+++ b/text/choc_JSON.h
@@ -46,14 +46,14 @@ struct ParseError  : public std::runtime_error
 
 /// Parses some JSON text into a choc::value::Value object, using the given pool.
 /// Any errors will result in a ParseError exception being thrown.
-value::Value parse (text::UTF8Pointer);
+[[nodiscard]] value::Value parse (text::UTF8Pointer);
 
 /// Parses some JSON text into a choc::value::Value object, using the given pool.
 /// Any errors will result in a ParseError exception being thrown.
-value::Value parse (std::string_view);
+[[nodiscard]] value::Value parse (std::string_view);
 
 /// Attempts to parse a bare JSON value such as a number, string, object etc
-value::Value parseValue (std::string_view);
+[[nodiscard]] value::Value parseValue (std::string_view);
 
 /// A helper function to create a JSON-friendly Value object with a set of properties.
 /// The argument list must be contain pairs of names and values, e.g.
@@ -65,13 +65,13 @@ value::Value parseValue (std::string_view);
 /// Essentially, this is a shorthand for calling choc::value::createObject()
 /// and passing it an empty type name.
 template <typename... Properties>
-value::Value create (Properties&&... propertyNamesAndValues);
+[[nodiscard]] value::Value create (Properties&&... propertyNamesAndValues);
 
 //==============================================================================
 /// Formats a value as a JSON string.
 /// If useLineBreaks is true, it'll be formatted as multi-line JSON, if false it'll
 /// just be returned as a single line.
-std::string toString (const value::ValueView&, bool useLineBreaks = false);
+[[nodiscard]] std::string toString (const value::ValueView&, bool useLineBreaks = false);
 
 /// Writes a version of a string to an output stream, with any illegal or non-ascii
 /// written as their equivalent JSON escape sequences.
@@ -80,15 +80,15 @@ void writeWithEscapeCharacters (OutputStreamType&, text::UTF8Pointer sourceStrin
 
 /// Returns a version of a string with illegal or non-ascii converted into the
 /// equivalent JSON escape sequences.
-std::string addEscapeCharacters (text::UTF8Pointer sourceString);
+[[nodiscard]] std::string addEscapeCharacters (text::UTF8Pointer sourceString);
 
 /// Returns a version of a string with illegal or non-ascii converted into the
 /// equivalent JSON escape sequences.
-std::string addEscapeCharacters (std::string_view sourceString);
+[[nodiscard]] std::string addEscapeCharacters (std::string_view sourceString);
 
 /// Returns a version of a string with illegal or non-ascii converted into the
 /// equivalent JSON escape sequences.
-std::string getEscapedQuotedString (std::string_view sourceString);
+[[nodiscard]] std::string getEscapedQuotedString (std::string_view sourceString);
 
 /// Converts a double to a JSON-format string representation.
 std::string doubleToString (double value);

--- a/text/choc_StringUtilities.h
+++ b/text/choc_StringUtilities.h
@@ -40,77 +40,80 @@ inline bool isDigit (char c)                                    { return static_
 /// The arguments must be a sequence of pairs of strings, where the first of each pair is the string to
 /// look for, followed by its replacement.
 template <typename StringType, typename... OtherReplacements>
-std::string replace (StringType textToSearch,
-                     std::string_view firstSubstringToReplace, std::string_view firstReplacement,
-                     OtherReplacements&&... otherPairsOfStringsToReplace);
+[[nodiscard]] std::string replace (StringType textToSearch,
+                                   std::string_view firstSubstringToReplace, std::string_view firstReplacement,
+                                   OtherReplacements&&... otherPairsOfStringsToReplace);
 
 /// Returns a string with any whitespace trimmed from its start and end.
-std::string trim (std::string textToTrim);
+[[nodiscard]] std::string trim (std::string textToTrim);
 
 /// Returns a string with any whitespace trimmed from its start and end.
-std::string_view trim (std::string_view textToTrim);
+[[nodiscard]] std::string_view trim (std::string_view textToTrim);
 
 /// Returns a string with any whitespace trimmed from its start and end.
-std::string_view trim (const char* textToTrim);
+[[nodiscard]] std::string_view trim (const char* textToTrim);
 
 /// Returns a string with any whitespace trimmed from its start.
-std::string trimStart (std::string textToTrim);
+[[nodiscard]] std::string trimStart (std::string textToTrim);
 
 /// Returns a string with any whitespace trimmed from its start.
-std::string_view trimStart (std::string_view textToTrim);
+[[nodiscard]] std::string_view trimStart (std::string_view textToTrim);
 
 /// Returns a string with any whitespace trimmed from its start.
-std::string_view trimStart (const char* textToTrim);
+[[nodiscard]] std::string_view trimStart (const char* textToTrim);
 
 /// Returns a string with any whitespace trimmed from its end.
-std::string trimEnd (std::string textToTrim);
+[[nodiscard]] std::string trimEnd (std::string textToTrim);
 
 /// Returns a string with any whitespace trimmed from its end.
-std::string_view trimEnd (std::string_view textToTrim);
+[[nodiscard]] std::string_view trimEnd (std::string_view textToTrim);
 
 /// Returns a string with any whitespace trimmed from its end.
-std::string_view trimEnd (const char* textToTrim);
+[[nodiscard]] std::string_view trimEnd (const char* textToTrim);
 
 /// If the string begins with one or more instances of the given character, this
 /// skips past them, returning the remainder of the string.
-std::string_view trimCharacterAtStart (std::string_view textToTrim, char characterToSkip);
+[[nodiscard]] std::string_view trimCharacterAtStart (std::string_view textToTrim, char characterToSkip);
 
 /// If the given character is at the start and end of the string, it trims it away.
-std::string removeOuterCharacter (std::string text, char outerChar);
+[[nodiscard]] std::string removeOuterCharacter (std::string text, char outerChar);
 
-inline std::string removeDoubleQuotes (std::string text)       { return removeOuterCharacter (std::move (text), '"'); }
-inline std::string removeSingleQuotes (std::string text)       { return removeOuterCharacter (std::move (text), '\''); }
+[[nodiscard]] inline std::string removeDoubleQuotes (std::string text)       { return removeOuterCharacter (std::move (text), '"'); }
+[[nodiscard]] inline std::string removeSingleQuotes (std::string text)       { return removeOuterCharacter (std::move (text), '\''); }
 
-inline std::string addDoubleQuotes (std::string text)          { return "\"" + std::move (text) + "\""; }
-inline std::string addSingleQuotes (std::string text)          { return "'" + std::move (text) + "'"; }
+[[nodiscard]] inline std::string addDoubleQuotes (std::string text)          { return "\"" + std::move (text) + "\""; }
+[[nodiscard]] inline std::string addSingleQuotes (std::string text)          { return "'" + std::move (text) + "'"; }
 
-std::string toLowerCase (std::string);
-std::string toUpperCase (std::string);
+[[nodiscard]] std::string toLowerCase (std::string);
+[[nodiscard]] std::string toUpperCase (std::string);
 
 template <typename IsDelimiterChar>
-std::vector<std::string> splitString (std::string_view textToSplit,
-                                      IsDelimiterChar&& isDelimiterChar,
-                                      bool includeDelimitersInResult);
+[[nodiscard]] std::vector<std::string> splitString (std::string_view textToSplit,
+                                                    IsDelimiterChar&& isDelimiterChar,
+                                                    bool includeDelimitersInResult);
 
 template <typename CharStartsDelimiter, typename CharIsInDelimiterBody>
-std::vector<std::string> splitString (std::string_view textToSplit,
-                                      CharStartsDelimiter&& isDelimiterStart,
-                                      CharIsInDelimiterBody&& isDelimiterBody,
-                                      bool includeDelimitersInResult);
+[[nodiscard]] std::vector<std::string> splitString (std::string_view textToSplit,
+                                                    CharStartsDelimiter&& isDelimiterStart,
+                                                    CharIsInDelimiterBody&& isDelimiterBody,
+                                                    bool includeDelimitersInResult);
 
-std::vector<std::string> splitString (std::string_view textToSplit,
-                                      char delimiterCharacter,
-                                      bool includeDelimitersInResult);
+[[nodiscard]] std::vector<std::string> splitString (std::string_view textToSplit,
+                                                    char delimiterCharacter,
+                                                    bool includeDelimitersInResult);
 
-std::vector<std::string> splitAtWhitespace (std::string_view text, bool keepDelimiters = false);
+[[nodiscard]] std::vector<std::string> splitAtWhitespace (std::string_view text,
+                                                          bool keepDelimiters = false);
 
 /// Splits a string at newline characters, returning an array of strings.
-std::vector<std::string> splitIntoLines (std::string_view text, bool includeNewLinesInResult);
+[[nodiscard]] std::vector<std::string> splitIntoLines (std::string_view text,
+                                                       bool includeNewLinesInResult);
 
 /// Joins some kind of array of strings into a single string, adding the given separator
 /// between them (but not adding it at the start or end)
 template <typename ArrayOfStrings>
-std::string joinStrings (const ArrayOfStrings& strings, std::string_view separator);
+[[nodiscard]] std::string joinStrings (const ArrayOfStrings& strings,
+                                       std::string_view separator);
 
 /// Returns true if this text contains the given sub-string.
 bool contains (std::string_view text, std::string_view possibleSubstring);

--- a/text/choc_UTF8.h
+++ b/text/choc_UTF8.h
@@ -101,14 +101,14 @@ struct UTF8Pointer
 
     /// Returns a pointer to the first non-whitespace character in the given string (which may
     /// be the terminating null character if it's all whitespace).
-    UTF8Pointer findEndOfWhitespace() const;
+    [[nodiscard]] UTF8Pointer findEndOfWhitespace() const;
 
     /// Iterates backwards from this position to find the first character that follows
     /// a new-line. The pointer provided marks the furthest back that the function should search
-    UTF8Pointer findStartOfLine (UTF8Pointer startOfValidText) const;
+    [[nodiscard]] UTF8Pointer findStartOfLine (UTF8Pointer startOfValidText) const;
 
     /// Searches forwards for the next character that is followed by a new-line or a null-terminator.
-    UTF8Pointer findEndOfLine() const;
+    [[nodiscard]] UTF8Pointer findEndOfLine() const;
 
     //==============================================================================
     struct EndIterator {};
@@ -198,7 +198,7 @@ bool isValidCESU8 (std::string_view utf8);
 
 /// Converts any 32-bit characters in this UTF-8 string to surrogate pairs, which makes
 /// the resulting string suitable for use at CESU-8.
-std::string convertUTF8ToCESU8 (UTF8Pointer);
+[[nodiscard]] std::string convertUTF8ToCESU8 (UTF8Pointer);
 
 
 //==============================================================================


### PR DESCRIPTION
This pulls in the latest from upstream/develop:
- fixes `performKeyEquivalent` on macOS (https://github.com/Tracktion/choc/issues/56)
- adds a config, `enableDefaultClipboardKeyShortcutsInSafari`, to disable copy commands on macOS

This PR also adds some additional config options:
- `enableSpaceToScroll`: controls the webview behavior of scrolling when space is pressed
- `enableWindowsAcceleratorKeys`: controls accelerator keys on Windows, such as Ctrl+P for print and Ctrl+F for find-in-page (see https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2settings3?view=webview2-1.0.2592.51#get_arebrowseracceleratorkeysenabled). 
  - unlike mac, this does not automatically allowed accelerator events to be forwarded to other views (e.g. undo), so they have to be handled and forwarded separately.