### PR TITLE
Adopt splice/pr-risk-classifier (classify + feedback + cycle-time)

### DIFF
--- a/.github/workflows/pr-cycle-time.yml
+++ b/.github/workflows/pr-cycle-time.yml
@@ -1,0 +1,22 @@
+name: PR Cycle Time
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to emit cycle-time metric for (workflow_dispatch only).'
+        required: true
+        type: string
+
+jobs:
+  emit:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    uses: splice/pr-risk-classifier/.github/workflows/cycle-time.yml@v1
+    permissions:
+      contents: read
+      pull-requests: read
+    with:
+      pr_number: ${{ inputs.pr_number }}
+    secrets: inherit

--- a/.github/workflows/pr-risk-check.yml
+++ b/.github/workflows/pr-risk-check.yml
@@ -1,0 +1,23 @@
+name: PR Risk Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to classify (workflow_dispatch only).'
+        required: true
+        type: string
+
+jobs:
+  classify:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.user.login == 'splicebot'
+    uses: splice/pr-risk-classifier/.github/workflows/classify.yml@v1
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    with:
+      pr_number: ${{ inputs.pr_number }}
+    secrets: inherit

--- a/.github/workflows/pr-risk-feedback.yml
+++ b/.github/workflows/pr-risk-feedback.yml
@@ -1,0 +1,18 @@
+name: PR Risk Feedback
+
+on:
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  feedback:
+    uses: splice/pr-risk-classifier/.github/workflows/feedback.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write   # for SSM-sourced Linear API key (VEL-345 auto-filer)
+    secrets: inherit


### PR DESCRIPTION
## Summary
Adopts the advisory PR risk classifier from [splice/pr-risk-classifier@v1](https://github.com/splice/pr-risk-classifier).

Three consumer stubs:
- `pr-risk-check.yml` — classifies splicebot/Renovate PRs
- `pr-risk-feedback.yml` — captures `/risk-feedback` / `/risk-agree` engineer signals (with `id-token: write` for SSM-sourced Linear key once VEL-345 ships)
- `pr-cycle-time.yml` — emits cycle_hours + time_to_ready_hours on merge ([VEL-343](https://linear.app/splice/issue/VEL-343))

Phase 1 advisory-only: every PR still requires engineer review. Risk labels created on this repo.